### PR TITLE
add columns v4617 v4618 to dom2001 in PNAD 

### DIFF
--- a/National Health Interview Survey/download all microdata.R
+++ b/National Health Interview Survey/download all microdata.R
@@ -88,7 +88,6 @@ csv <- FALSE
 # no need to edit anything below this line #
 
 
-if ( 2015 %in% nhis.years.to.download ) message( "2015 imputed income not yet available" )
 
 
 # # # # # # # # #
@@ -401,8 +400,8 @@ for ( year in nhis.years.to.download ){
 	###########################
 	
 	# if the year is after 1996, then download the imputed income files
-	# if ( year > 1996 ){
-	if ( year %in% 1997:2014 ){
+	if ( year > 1996 ){
+	# if ( year %in% 1997:2014 ){
 		
 		# imputed income files must be downloaded using a different method #
 	

--- a/Pesquisa Nacional por Amostra de Domicilios/download all microdata.R
+++ b/Pesquisa Nacional por Amostra de Domicilios/download all microdata.R
@@ -347,6 +347,9 @@ for ( year in years.to.download ){
 	# add 4617 and 4618 to 2001 file
 	if( year == 2001 ){
 	
+		dbSendQuery( db , "ALTER TABLE dom2001 ADD COLUMN v4617 real" )
+		dbSendQuery( db , "ALTER TABLE dom2001 ADD COLUMN v4618 real" )
+	
 		dbSendQuery( db , "UPDATE dom2001 SET v4617 = strat" )
 		dbSendQuery( db , "UPDATE dom2001 SET v4618 = psu" )
 		

--- a/Pesquisa Nacional por Amostra de Domicilios/download all microdata.R
+++ b/Pesquisa Nacional por Amostra de Domicilios/download all microdata.R
@@ -347,7 +347,6 @@ for ( year in years.to.download ){
 	# add 4617 and 4618 to 2001 file
 	if( year == 2001 ){
 	
-		dbSendQuery( db , paste0( 'alter table dom2001 add column pre_wgt real' ) )
 		dbSendQuery( db , "UPDATE dom2001 SET v4617 = strat" )
 		dbSendQuery( db , "UPDATE dom2001 SET v4618 = psu" )
 		
@@ -456,8 +455,8 @@ for ( year in years.to.download ){
 	# if it's not in there, copy it over
 	dbSendQuery( db , paste0( 'alter table pnad' , year , ' add column pre_wgt real' ) )
 
-	if( year == 2001 ){
-		dbSendQuery( db , paste0( 'update pnad' , year , ' set pre_wgt = v4610 * v4729' ) )
+	if( year < 2004 ){
+		dbSendQuery( db , paste0( 'update pnad' , year , ' set pre_wgt = v4610' ) )
 	} else {
 		dbSendQuery( db , paste0( 'update pnad' , year , ' set pre_wgt = v4619 * v4610' ) )	
 	}

--- a/Pesquisa Nacional por Amostra de Domicilios/download all microdata.R
+++ b/Pesquisa Nacional por Amostra de Domicilios/download all microdata.R
@@ -344,6 +344,14 @@ for ( year in years.to.download ){
 	# weird brazilian file encoding operates differently on mac+*nix versus windows, so try both ways.
 	if( class( attempt.one ) == 'try-error' ) { Encoding( files ) <- '' ; file.remove( files ) }
 	
+	# add 4617 and 4618 to 2001 file
+	if( year == 2001 ){
+	
+		dbSendQuery( db , paste0( 'alter table dom2001 add column pre_wgt real' ) )
+		dbSendQuery( db , "UPDATE dom2001 SET v4617 = strat" )
+		dbSendQuery( db , "UPDATE dom2001 SET v4618 = psu" )
+		
+	}
 	
 	# missing level blank-outs #
 	# this section loops through the non-response values & variables for all years
@@ -447,8 +455,12 @@ for ( year in years.to.download ){
 	# now create the pre-stratified weight to be used in all of the survey designs
 	# if it's not in there, copy it over
 	dbSendQuery( db , paste0( 'alter table pnad' , year , ' add column pre_wgt real' ) )
-	dbSendQuery( db , paste0( 'update pnad' , year , ' set pre_wgt = v4619 * v4610' ) )
-	
+
+	if( year == 2001 ){
+		dbSendQuery( db , paste0( 'update pnad' , year , ' set pre_wgt = v4610 * v4729' ) )
+	} else {
+		dbSendQuery( db , paste0( 'update pnad' , year , ' set pre_wgt = v4619 * v4610' ) )	
+	}
 	
 	# confirm that the number of records in the pnad merged file
 	# matches the number of records in the person file


### PR DESCRIPTION
I tried redownloading the microdata using the update download all microdata.R script.
But the following error popped out:

```
Error in .local(conn, statement, ...) : 
  Unable to execute statement 'update dom2001 set v4617 = strat'.
Server says 'ParseException:SQLparser:42S22!UPDATE: no such column 'dom2001.v4617''.
In addition: There were 35 warnings (use warnings() to see them)
```

I think 

```
    dbSendQuery( db , paste0( "alter table dom2001 add column v4617 real" ) )
    dbSendQuery( db , paste0( "alter table dom2001 add column v4618 real" ) )
```

should be added to the section 

```
  # add 4617 and 4618 to 2001 file
  if( year == 2001 ){

    dbSendQuery( db , "update dom2001 set v4617 = strat" )
    dbSendQuery( db , "update dom2001 set v4618 = psu" )

  }
```
